### PR TITLE
Arch.pm: Fix META.json parsing

### DIFF
--- a/lib/CPANPLUS/Dist/Arch.pm
+++ b/lib/CPANPLUS/Dist/Arch.pm
@@ -1582,7 +1582,7 @@ sub _scanmeta
 
     # Leave metareqs undef if there is no META.yml/META.json.
     my $path = _metapath($modobj) or return;    
-    my $meta = eval { Parse::CPAN::Meta::LoadFile($path) };
+    my $meta = eval { Parse::CPAN::Meta->load_file($path) };
     return unless ($meta);
 
     my $reqs = _metareqs($meta);


### PR DESCRIPTION
`Meta::LoadFile` only works on YAML files (for some reason). `load_file` is the correct method to call.

Fixes bence98/cpan2aur2git#4