### PR TITLE
Fix bugs and align with current Arch guidelines

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,7 @@ WriteMakefile(
     'NAME' => 'CPANPLUS::Dist::Arch',
     'ABSTRACT' => 'CPANPLUS backend for building ArchLinux pacman packages',
     'AUTHOR' => 'John D Jones III <jnbek@cpan.org>',
-    'VERSION' => '1.32',
+    'VERSION' => '1.33',
     'LICENSE' => 'perl_5',
     'PREREQ_PM' => { @reqs },
     'META_ADD' => $meta,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,6 +25,7 @@ WriteMakefile(
     'ABSTRACT' => 'CPANPLUS backend for building ArchLinux pacman packages',
     'AUTHOR' => 'John D Jones III <jnbek@cpan.org>',
     'VERSION' => '1.32',
+    'LICENSE' => 'perl_5',
     'PREREQ_PM' => { @reqs },
     'META_ADD' => $meta,
     'EXE_FILES' => \@scripts,

--- a/lib/CPANPLUS/Dist/Arch.pm
+++ b/lib/CPANPLUS/Dist/Arch.pm
@@ -34,7 +34,7 @@ use Cwd                    qw();
 
 
 my $MKPKGCONF_FQP = '/etc/makepkg.conf';
-my $CPANURL       = 'http://search.cpan.org';
+my $CPANURL       = 'https://search.cpan.org';
 my $ROOT_USER_ID  = 0;
 
 my $CFG_VALUE_MATCH  = '\A \s* (%s) \s* = \s* (.*?) \s* (?: \#.* )? \z';

--- a/lib/CPANPLUS/Dist/Arch.pm
+++ b/lib/CPANPLUS/Dist/Arch.pm
@@ -32,6 +32,7 @@ use Cwd                    qw();
 # CLASS CONSTANTS
 #-----------------------------------------------------------------------------
 
+my $PERL5_LIC = "'PerlArtistic' 'GPL'";
 
 my $MKPKGCONF_FQP = '/etc/makepkg.conf';
 my $CPANURL       = 'https://search.cpan.org';
@@ -79,6 +80,49 @@ TermReadKey    = perl-term-readkey
 
 END_OVERRIDES
 
+my $LICENSE_MAP =
+{ map { split /\s*=\s*/ } split /\s*\n+\s*/, <<'END_LICENSES' };
+
+perl_5      = 'PerlArtistic' 'GPL'
+
+apache_1_1  = 'Apache 1.1'
+apache_2_0  = 'Apache 2.0'
+artistic_1  = 'PerlArtistic'
+artistic_2  = 'Artistic2.0'
+agpl_3      = 'AGPL3'
+gpl_2       = 'GPL2'
+gpl_3       = 'GPL3'
+lgpl_2_1    = 'LGPL2'
+lgpl_3_0    = 'LGPL3'
+gfdl_1_2    = 'FDL1.2'
+gfdl_1_3    = 'FDL1.3'
+mozilla_1_0 = 'MPL 1.0'
+mozilla_1_1 = 'MPL 1.1'
+
+gpl_1       = 'custom:GPLv1'
+openssl     = 'custom:OpenSSL License'
+qpl_1_0     = 'custom:Q Public License, Version 1.0'
+ssleay      = 'custom:Original SSLeay License'
+sun         = 'custom:Sun Internet Standards Source License (SISSL)'
+
+bsd         = 'BSD'
+freebsd     = 'BSD'
+mit         = 'MIT'
+zlib        = 'ZLIB'
+
+perl        = 'PerlArtistic' 'GPL'
+apache      = 'Apache 2.0'
+artistic    = 'PerlArtistic'
+lgpl        = 'LGPL2'
+lgpl2       = 'LGPL2'
+lgpl3       = 'LGPL3'
+gpl         = 'GPL'
+gpl2        = 'GPL2'
+gpl3        = 'GPL3'
+mozilla     = 'MPL 1.1'
+
+END_LICENSES
+
 # This var tells us whether to use a template module or our internal code:
 my $TT_MOD_NAME;
 my @TT_MOD_SEARCH = qw/ Template Template::Alloy Template::Tiny /;
@@ -104,7 +148,7 @@ pkgver='[% pkgver %]'
 pkgrel='[% pkgrel %]'
 pkgdesc="[% pkgdesc %]"
 arch=([% arch %])
-license=('PerlArtistic' 'GPL')
+license=([% license %])
 options=('!emptydirs')
 depends=([% depends %])
 makedepends=([% makedepends %])
@@ -284,6 +328,7 @@ sub init
     $self->status->mk_accessors( qw{ pkgname  pkgver  pkgbase pkgdesc
                                      pkgurl   pkgsize arch    pkgrel
                                      builddir destdir metareqs
+                                     license
 
                                      pkgbuild_templ tt_init_args } );
 
@@ -689,6 +734,7 @@ sub get_pkgvars
                 pkgrel   => $status->pkgrel,
                 arch     => $status->arch,
                 pkgdesc  => $status->pkgdesc,
+                license  => $status->license,
                 url      => $self->_get_disturl,
                 source   => $self->_get_srcurl,
                 md5sums  => $self->_calc_tarballmd5,
@@ -1568,7 +1614,32 @@ sub _metadesc
         return if ( $d eq $b );
     }
     return $d;
-    
+}
+
+sub _metalic
+{
+    my ($meta) = @_;
+    my $lic_str = $meta->{'x_spdx_expression'} || "";
+
+    return "'$lic_str'" if $lic_str;
+
+    # Some very old, pre-standard metafiles don't have this key at all...
+    return unless $meta->{'license'};
+
+    # And depending on the spec version, it may be a string or an array
+    my $lics = ref $meta->{'license'} eq 'ARRAY' ?
+        $meta->{'license'} :
+        [$meta->{'license'}];
+
+    for my $l (@$lics) {
+        next unless $l;
+        $l = $LICENSE_MAP->{$l};
+        next unless $l;
+        $lic_str .= " " if $lic_str;
+        $lic_str .= "$l";
+    }
+
+    return $lic_str;
 }
 
 #--- PRIVATE METHOD ---
@@ -1587,8 +1658,10 @@ sub _scanmeta
 
     my $reqs = _metareqs($meta);
     my $desc = _metadesc($meta);
+    my $lic  = _metalic($meta);
     $status->metareqs($reqs);
     $status->pkgdesc($desc);
+    $status->license($lic) if $lic;
     return;
 }
 
@@ -1623,6 +1696,7 @@ sub _prepare_status
     $status->pkgver ( $pkgver  );
     $status->pkgbase( $pkgbase );
     $status->pkgrel (    1     );
+    $status->license($PERL5_LIC);
 
     $status->tt_init_args( {} );
 

--- a/lib/CPANPLUS/Dist/Arch.pm
+++ b/lib/CPANPLUS/Dist/Arch.pm
@@ -1563,7 +1563,7 @@ sub _metadesc
     my $d = $meta->{'abstract'} or return undef;
 
     # META.yml abstract entries we should ignore.
-    my @bad = ( q{~}, 'Module abstract (<= 44 characters) goes here' );
+    my @bad = ( q{~}, 'Module abstract (<= 44 characters) goes here', 'unknown' );
     for my $b ( @bad ) {
         return if ( $d eq $b );
     }

--- a/lib/CPANPLUS/Dist/Arch.pm
+++ b/lib/CPANPLUS/Dist/Arch.pm
@@ -6,7 +6,7 @@ use strict;
 use CPANPLUS::Dist::Base   qw();
 use Exporter               qw(import);
 
-our $VERSION     = '1.32';
+our $VERSION     = '1.33';
 our @EXPORT      = qw();
 our @EXPORT_OK   = qw(dist_pkgname dist_pkgver);
 our %EXPORT_TAGS = ( 'all' => [ @EXPORT_OK ] );

--- a/lib/CPANPLUS/Dist/Arch.pm
+++ b/lib/CPANPLUS/Dist/Arch.pm
@@ -790,7 +790,7 @@ sub get_pkgbuild
           $dist_type eq 'CPANPLUS::Dist::Build' ? (0, 1) :
           die "unknown Perl module installer type: '$dist_type'" );
 
-    my $templ_text = $status->pkgbuild_templ || $PKGBUILD_TEMPL;
+    my $templ_text = $self->get_pkgbuild_templ;
 
     return scalar $self->_process_template( $templ_text, $templ_vars );
 }

--- a/lib/CPANPLUS/Dist/Arch.pm
+++ b/lib/CPANPLUS/Dist/Arch.pm
@@ -162,7 +162,7 @@ package() {
   /usr/bin/perl Build install
 [% END -%]
 
-  find "$pkgdir" -name .packlist -o -name perllocal.pod -delete
+  find "$pkgdir" "(" -name .packlist -o -name perllocal.pod ")" -delete
 }
 
 # Local Variables:

--- a/lib/CPANPLUS/Dist/Arch.pm
+++ b/lib/CPANPLUS/Dist/Arch.pm
@@ -827,6 +827,8 @@ sub get_pkgbuild
 
     my %pkgvars = $self->get_pkgvars;
 
+    # Trim extra whitespace
+    $pkgvars{pkgdesc} =~ s/\A\s+|\s+\z//g;
     # Quote our package desc for bash.
     $pkgvars{pkgdesc} =~ s/ ([\$\"\`]) /\\$1/gxms;
 

--- a/lib/CPANPLUS/Dist/Arch.pm
+++ b/lib/CPANPLUS/Dist/Arch.pm
@@ -149,7 +149,7 @@ pkgrel='[% pkgrel %]'
 pkgdesc="[% pkgdesc %]"
 arch=([% arch %])
 license=([% license %])
-options=('!emptydirs')
+options=('!emptydirs' 'purge')
 depends=([% depends %])
 makedepends=([% makedepends %])
 [% IF checkdepends -%]

--- a/lib/CPANPLUS/Dist/Arch.pm
+++ b/lib/CPANPLUS/Dist/Arch.pm
@@ -164,6 +164,9 @@ md5sums=('[% md5sums %]')
 [% IF sha512sums -%]
 sha512sums=('[% sha512sums %]')
 [% END -%]
+[% IF b2sums -%]
+b2sums=('[% b2sums %]')
+[% END -%]
 _distdir="[% distdir %]"
 
 build() {
@@ -742,6 +745,9 @@ sub get_pkgvars
     );
     if (eval { require Digest::SHA }) {
         $vars{'sha512sums'} = $self->_calc_shasum(512);
+    }
+    if (eval { require Crypt::Digest::BLAKE2b_512 }) {
+        $vars{'b2sums'} = $self->_calc_b2sum();
     }
 
     $vars{$_} = _specstr($pkglinks->{$_}) for (qw/depends makedepends/);
@@ -1780,6 +1786,23 @@ sub _calc_shasum
     die "failed to get sha${size}sum of $fqp:\n$EVAL_ERROR";
 }
 
+#---INSTANCE METHOD---
+# Usage    : my $b2sum = $self->calc_b2sum();
+# Purpose  : Calculates the BLAKE2b 512-bit digest (b2sum).
+# Throws   : failed to get b2sum of <tarball>:\n...
+# Returns  : Hex-string checksum of the tarball.
+#---------------------
+sub _calc_b2sum
+{
+    my ($self) = @_;
+    my $module = $self->parent;
+    my $fqp    = $module->_status->fetch;
+    my $sum    = eval {
+        Crypt::Digest::BLAKE2b_512->new->addfile( $fqp )->hexdigest;
+    };
+    return $sum if $sum;
+    die "failed to get b2sum of $fqp:\n$EVAL_ERROR";
+}
 
 #---HELPER FUNCTION---
 # Purpose : Split the text into everything before the tags, inside tags, and

--- a/t/05-custom_template.t
+++ b/t/05-custom_template.t
@@ -41,6 +41,7 @@ depends = 'perl>=5.010'
 distdir = Template-Tester-1.342
 is_makemaker = 0
 is_modulebuild = 1
+license = 'PerlArtistic' 'GPL'
 makedepends = 
 md5sums = 12345MD5SUM12345
 packager = $CPANPLUS::Dist::Arch::PACKAGER

--- a/t/05-custom_template.t
+++ b/t/05-custom_template.t
@@ -49,7 +49,7 @@ pkgname = perl-template-tester
 pkgrel = 1
 pkgver = 1.342
 sha512sums = 12345SHA512SUM12345
-source = http://search.cpan.org/CPAN/J/JU/JUSTER/Template-Tester-1.342.tar.gz
+source = https://search.cpan.org/CPAN/J/JU/JUSTER/Template-Tester-1.342.tar.gz
 url = https://metacpan.org/release/Template-Tester
 version = $CPANPLUS::Dist::Arch::VERSION
 END_OUTPUT


### PR DESCRIPTION
Implement the following from [current Arch guidelines](https://wiki.archlinux.org/title/Perl_package_guidelines):
* use `https://` for `sources`
* use `purge` option
* fill out `license` field correctly
* add `b2sums` if [CryptX](https://metacpan.org/pod/Crypt::Digest::BLAKE2b_512) is available

Fix more bugs:
* package did not specify its own license
* [`find` command was broken](https://rt.cpan.org/Public/Bug/Display.html?id=123153)
* correctly guessed abstract (e.g. from pod) was overwritten by `"unknown"`

TODOs for the future:
* use SPDX license strings